### PR TITLE
feat: dynamic icon component

### DIFF
--- a/astro/package.json
+++ b/astro/package.json
@@ -12,6 +12,7 @@
     "astro": "^3.5.2"
   },
   "devDependencies": {
+    "@iconify/types": "^2.0.0",
     "autoprefixer": "^10.4.16",
     "cssnano": "^6.0.1",
     "sass": "^1.69.5"

--- a/astro/src/components/Icon.astro
+++ b/astro/src/components/Icon.astro
@@ -1,24 +1,14 @@
 ---
-import type { IconifyJSON } from "@iconify/types";
+import { getIcon } from "@/utils/iconifyIcon";
 
 interface Props extends astroHTML.JSX.SVGAttributes {
-  prefix: string;
   icon: string;
 }
 
-const { prefix, icon, ...rest } = Astro.props;
-const iconify = `https://api.iconify.design/${prefix}.json?icons=${icon}`;
+const { icon, ...rest } = Astro.props;
+const iconData = await getIcon(icon);
 
-const iconJson = await fetch(iconify).then<IconifyJSON>((r) => r.json());
-
-const iconData = iconJson.icons[icon];
-
-const viewBox = [
-  iconData.left ?? iconJson.left ?? 0,
-  iconData.top ?? iconJson.top ?? 0,
-  iconData.width ?? iconJson.width ?? 16,
-  iconData.height ?? iconJson.height ?? 16,
-].join(" ");
+const viewBox = [iconData.left, iconData.top, iconData.width, iconData.height].join(" ");
 ---
 
 <svg viewBox={viewBox} {...rest} set:html={iconData.body} />

--- a/astro/src/components/Icon.astro
+++ b/astro/src/components/Icon.astro
@@ -1,0 +1,24 @@
+---
+import type { IconifyJSON } from "@iconify/types";
+
+interface Props extends astroHTML.JSX.SVGAttributes {
+  prefix: string;
+  icon: string;
+}
+
+const { prefix, icon, ...rest } = Astro.props;
+const iconify = `https://api.iconify.design/${prefix}.json?icons=${icon}`;
+
+const iconJson = await fetch(iconify).then<IconifyJSON>((r) => r.json());
+
+const iconData = iconJson.icons[icon];
+
+const viewBox = [
+  iconData.left ?? iconJson.left ?? 0,
+  iconData.top ?? iconJson.top ?? 0,
+  iconData.width ?? iconJson.width ?? 16,
+  iconData.height ?? iconJson.height ?? 16,
+].join(" ");
+---
+
+<svg viewBox={viewBox} {...rest} set:html={iconData.body} />

--- a/astro/src/pages/index.astro
+++ b/astro/src/pages/index.astro
@@ -10,7 +10,7 @@ const posts = await getPosts();
   <main>
     <h1>Astroad</h1>
     <p>
-      <Icon prefix="mdi" icon="volleyball" width="64" height="64" />
+      <Icon icon="mdi:volleyball" width="64" height="64" />
       Astroad is a pre-configured setup for Astro and Payloadcms that makes it
       easy to get started with building your website. With Astroad, you'll have
       a complete development environment that you can run locally using Docker.

--- a/astro/src/pages/index.astro
+++ b/astro/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+import Icon from "@/components/Icon.astro";
 import Layout from "@/layouts/Layout.astro";
 import { getPosts } from "@/utils/payload";
 
@@ -9,6 +10,7 @@ const posts = await getPosts();
   <main>
     <h1>Astroad</h1>
     <p>
+      <Icon prefix="mdi" icon="volleyball" width="64" height="64" />
       Astroad is a pre-configured setup for Astro and Payloadcms that makes it
       easy to get started with building your website. With Astroad, you'll have
       a complete development environment that you can run locally using Docker.

--- a/astro/src/utils/iconifyIcon.ts
+++ b/astro/src/utils/iconifyIcon.ts
@@ -2,8 +2,8 @@ import type { IconifyIcon, IconifyJSON, IconifyOptional } from "@iconify/types";
 
 const TTL = 1000 * 60 * 60 * 24 * 7; // 1 week
 
-type RequiredIcon = Required<IconifyIcon>;
-type CacheValue = { icon: RequiredIcon; timeFetched: number };
+type FullIconifyIcon = Required<IconifyIcon>;
+type CacheValue = { icon: FullIconifyIcon; timeFetched: number };
 
 const cache = new Map<string, CacheValue>();
 
@@ -25,32 +25,25 @@ function separatePrefix(icon: string): [string, string] {
   return icon.split(":") as any;
 }
 
-async function fetchIcon(prefix: string, name: string): Promise<RequiredIcon> {
+async function fetchIcon(prefix: string, name: string): Promise<FullIconifyIcon> {
   const iconify = `https://api.iconify.design/${prefix}.json?icons=${name}`;
 
   const iconJson = await fetch(iconify).then<IconifyJSON>((r) => r.json());
   const iconData = iconJson.icons[name];
 
-  iconData.left ??= iconJson.left ?? iconifyDefault.left;
-  iconData.top ??= iconJson.top ?? iconifyDefault.top;
-  iconData.width ??= iconJson.width ?? iconifyDefault.width;
-  iconData.height ??= iconJson.height ?? iconifyDefault.height;
-
-  iconData.hFlip ??= iconifyDefault.hFlip;
-  iconData.vFlip ??= iconifyDefault.vFlip;
-  iconData.rotate ??= iconifyDefault.rotate;
-
   return {
-    ...iconifyDefault,
-    left: iconJson.left ?? iconifyDefault.left,
-    top: iconJson.top ?? iconifyDefault.top,
-    width: iconJson.width ?? iconifyDefault.width,
-    height: iconJson.height ?? iconifyDefault.height,
-    ...iconData,
+    left: iconData.left ?? iconJson.left ?? iconifyDefault.left,
+    top: iconData.top ?? iconJson.top ?? iconifyDefault.top,
+    width: iconData.width ?? iconJson.width ?? iconifyDefault.width,
+    height: iconData.height ?? iconJson.height ?? iconifyDefault.height,
+    hFlip: iconData.hFlip ?? iconifyDefault.hFlip,
+    vFlip: iconData.vFlip ?? iconifyDefault.vFlip,
+    rotate: iconData.rotate ?? iconifyDefault.rotate,
+    body: iconData.body,
   };
 }
 
-export async function getIcon(icon: string): Promise<RequiredIcon> {
+export async function getIcon(icon: string): Promise<FullIconifyIcon> {
   const cachedValue = cache.get(icon);
   if (cachedValue && Date.now() - cachedValue.timeFetched < TTL) {
     return cachedValue.icon;

--- a/astro/src/utils/iconifyIcon.ts
+++ b/astro/src/utils/iconifyIcon.ts
@@ -1,0 +1,63 @@
+import type { IconifyIcon, IconifyJSON, IconifyOptional } from "@iconify/types";
+
+const TTL = 1000 * 60 * 60 * 24 * 7; // 1 week
+
+type RequiredIcon = Required<IconifyIcon>;
+type CacheValue = { icon: RequiredIcon; timeFetched: number };
+
+const cache = new Map<string, CacheValue>();
+
+const iconifyDefault = {
+  left: 0,
+  top: 0,
+  width: 16,
+  height: 16,
+  hFlip: false,
+  vFlip: false,
+  rotate: 0,
+} as const satisfies { [key in keyof Required<IconifyOptional>]: IconifyOptional[key] };
+
+function separatePrefix(icon: string): [string, string] {
+  if (!/^\w+:\w+$/.test(icon)) {
+    throw new Error(`Invalid icon name: '${icon}'`);
+  }
+  // WARNING: any ¯\_(ツ)_/¯
+  return icon.split(":") as any;
+}
+
+async function fetchIcon(prefix: string, name: string): Promise<RequiredIcon> {
+  const iconify = `https://api.iconify.design/${prefix}.json?icons=${name}`;
+
+  const iconJson = await fetch(iconify).then<IconifyJSON>((r) => r.json());
+  const iconData = iconJson.icons[name];
+
+  iconData.left ??= iconJson.left ?? iconifyDefault.left;
+  iconData.top ??= iconJson.top ?? iconifyDefault.top;
+  iconData.width ??= iconJson.width ?? iconifyDefault.width;
+  iconData.height ??= iconJson.height ?? iconifyDefault.height;
+
+  iconData.hFlip ??= iconifyDefault.hFlip;
+  iconData.vFlip ??= iconifyDefault.vFlip;
+  iconData.rotate ??= iconifyDefault.rotate;
+
+  return {
+    ...iconifyDefault,
+    left: iconJson.left ?? iconifyDefault.left,
+    top: iconJson.top ?? iconifyDefault.top,
+    width: iconJson.width ?? iconifyDefault.width,
+    height: iconJson.height ?? iconifyDefault.height,
+    ...iconData,
+  };
+}
+
+export async function getIcon(icon: string): Promise<RequiredIcon> {
+  const cachedValue = cache.get(icon);
+  if (cachedValue && Date.now() - cachedValue.timeFetched < TTL) {
+    return cachedValue.icon;
+  }
+
+  const iconData = await fetchIcon(...separatePrefix(icon));
+  cache.set(icon, { icon: iconData, timeFetched: Date.now() });
+
+  return iconData;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "astro": "^3.5.2"
       },
       "devDependencies": {
+        "@iconify/types": "^2.0.0",
         "autoprefixer": "^10.4.16",
         "cssnano": "^6.0.1",
         "sass": "^1.69.5"
@@ -3163,6 +3164,12 @@
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/@fontsource/noto-serif-tc/-/noto-serif-tc-5.0.7.tgz",
       "integrity": "sha512-+V/AQ6Kt+YseS02Eos5v2FK3ZJ6lTEDKW5V2IVokci7DDkwJlB+s84JTt0e4t40UgqXvNtK8o9agcGGW+P6F7w=="
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true
     },
     "node_modules/@juggle/resize-observer": {
       "version": "3.4.0",


### PR DESCRIPTION
Automatically fetches icon SVGs from Iconify API,
with caching enabled (default for 7 days)

Usage
```jsx
<Icon icon="mdi:volleyball" width="64" height="64" ...otherProps />
```

An `icon` prop is required, with other `SVGElement` props available to use.